### PR TITLE
kubernetes networks

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -15,6 +15,13 @@ spec:
   containers:
   - name: nginx
     image: mariarti/nginx:latest
+    readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 8000
+    livenessProbe:
+        tcpSocket:
+          port: 8000
     volumeMounts:
     - name: app
       mountPath: /app

--- a/kubernetes-networks/canary/canary-ingress.yaml
+++ b/kubernetes-networks/canary/canary-ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: my-service.com
+    http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-20-1
+          servicePort: 8000
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web-canary
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+spec:
+  rules:
+  - host: my-service.com
+    http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-20-2
+          servicePort: 8000

--- a/kubernetes-networks/canary/canary-svc.yaml
+++ b/kubernetes-networks/canary/canary-svc.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-20-1
+  labels:
+    app: web
+spec:
+  selector:
+    release: 20-1
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-20-1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+      release: 20-1
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+        release: 20-1
+    spec:
+      containers:
+      - name: nginx
+        image: mariarti/nginx:latest
+        readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+        livenessProbe:
+            tcpSocket:
+              port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: index-generator
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-20-2
+  labels:
+    app: web
+spec:
+  selector:
+    release: 20-2
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-20-2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+      release: 20-2
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+        release: 20-2
+    spec:
+      containers:
+      - name: nginx
+        image: mariarti/nginx:latest
+        readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+        livenessProbe:
+            tcpSocket:
+              port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: index-generator
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%

--- a/kubernetes-networks/coredns/coredns-svc-lb.yaml
+++ b/kubernetes-networks/coredns/coredns-svc-lb.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-udp-svc-lb
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: UDP
+      port: 53
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-tcp-svc-lb
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 53
+      name: tcp-first
+    - protocol: TCP
+      port: 9153
+      name: tcp-second

--- a/kubernetes-networks/coredns/coredns-svc-lb.yaml
+++ b/kubernetes-networks/coredns/coredns-svc-lb.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: coredns-udp-svc-lb
+  namespace: kube-system
   annotations:
     metallb.universe.tf/allow-shared-ip: coredns
 spec:
@@ -16,6 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: coredns-tcp-svc-lb
+  namespace: kube-system
   annotations:
     metallb.universe.tf/allow-shared-ip: coredns
 spec:

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+    ingress.kubernetes.io/ssl-passthrough: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # adds 301 redirect with trailing slash
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ permanent;
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        backend:
+          serviceName: kubernetes-dashboard
+          servicePort: 443

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -8,10 +8,10 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/secure-backends: "true"
     ingress.kubernetes.io/ssl-passthrough: "false"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     # adds 301 redirect with trailing slash
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite ^(/dashboard)$ $1/ permanent;
+      rewrite "(?i)/dashboard(/|$)(.*)" /$2 break;
 spec:
   rules:
   - http:

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+      - name: default
+        protocol: layer2
+        addresses:
+          - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: nginx
+        image: mariarti/nginx:latest
+        readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+        livenessProbe:
+            tcpSocket:
+              port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: index-generator
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со * DNS через MetalLB
 - [x] Задание со * Ingress для Dashboard
 - [x] Задание со * Canary для Ingress

## В процессе сделано:
### Работа с тестовым веб-приложением
- Добавлены `readinessProbe` и `livenessProbe`
- Создан объект типа `Deployment`
- Создан объект типа `Service` (ClusterIP)
- Включен режим балансировки IPVS

### Доступ к приложению извне кластера
- Установлен MetalLB в Layer2-режиме
- Добавлен сервиса LoadBalancer для веб-приложения
- Выполнено задание со :star:|| DNS через MetalLB
- Выполнено задание со ⭐️|| Ingress для Dashboard
- Выполнено задание со ⭐️ || Canary для Ingress
## Как запустить проект:
```
kubectl apply -f web-pod.yaml --validate
kubectl apply -f web-deploy.yaml --validate
kubectl apply -f web-svc-cip.yaml --validate
```
```
kubectl apply -f web-svc-lb.yaml --validate
kubectl apply -f coredns/coredns-svc-lb.yaml --validate
kubectl apply -f nginx-lb.yaml --validate
kubectl apply -f web-svc-headless.yaml --validate
kubectl apply -f web-ingress.yaml --validate
kubectl apply -f dashboard/dashboard-ingress.yaml --validate
kubectl apply -f canary/ --validate
```

## Как проверить работоспособность:
`kubectl get pods | grep web` должен быть в статусе `Running` и `Ready`
`kubectl get deployment web` деплоймент должен иметь `Ready = 3/3`
`curl http://<CLUSTER-IP>/index.html` из ноды с minikube

Задание со :star: || DNS через MetalLB
```
nslookup web-svc-cip.default.svc.cluster.local 172.17.255.2                                                                             
Server:		172.17.255.2
Address:	172.17.255.2#53

Name:	web-svc-cip.default.svc.cluster.local
Address: 10.96.16.17
```
Задание со :star: || Ingress для Dashboard
```
go to https://<LB_IP>/dashboard -> откроется логин пейдж для дашборды
```
Задание со :star: || Ingress для Canary.
Как видно из вывода команды - результаты близки к 50%, как и было задано аннотацией. 
```
ret_1=0; ret_2=0; while [[ $ret_1 != 100 ]]; do result=$(curl -H "Host: my-service.com" --silent <LB_IP>/web | grep HOSTNAME); if [[ $result =~ "20-1" ]]; then let "ret_1++"; else let "ret_2++"; fi; done; echo $ret_1; echo $ret_2
105
100
```
## PR checklist:
 - [x] Выставлен label с номером домашнего задания

## Ответы на вопросы
**1. Почему следующая конфигурация валидна, хотя не имеет смысла?**
```
livenessProbe:
  exec:
    command:
      - 'sh'
      - '-c'
      - 'ps aux | grep my_web_server_process'
```
Ответ: kubelet по умолчанию будет отслеживать exit code процесса в контейнере с PID = 1, соответственно, если основной процесс завершился с exit code = 1, контейнер будет автоматически рестартован.
**2. Бывают ли ситуации, когда такая проба имеет смысл?**
Ответ: Например, если родительский процесс порождает несколько дочерних и нужно отслеживать успешность их запуска. 